### PR TITLE
Update VAT rates as of 04/2026

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,12 +10,9 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.3"
-          - "7.4"
-          - "8.0"
-          - "8.1"
-          - "8.2"
           - "8.3"
+          - "8.4"
+          - "8.5"
 
     steps:
     - uses: actions/checkout@v3

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
 		}
 	],
 	"require": {
-		"php": "^7.3 || ^8.0",
+		"php": "^8.3",
 		"ext-soap": "*"
 	},
 	"require-dev": {
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0",
-		"phpstan/phpstan": "^1.3",
-		"phpunit/php-timer": "^5.0",
-		"phpunit/phpunit": "^9.4",
+		"phpstan/phpstan": "^2.1",
+		"phpunit/php-timer": "^7.0",
+		"phpunit/phpunit": "^11.5",
 		"spaze/coding-standard": "^1.3"
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
 		"lint": "vendor/bin/parallel-lint --colors src/ tests/",
 		"phpcs": "vendor/bin/phpcs src/ tests/",
 		"phpstan-dev": "vendor/bin/phpstan --ansi analyse --configuration phpstan.neon",
-		"phpunit-dev": "php vendor/phpunit/phpunit/phpunit --colors=always --verbose",
+		"phpunit-dev": "php vendor/phpunit/phpunit/phpunit --colors=always --testdox",
 		"test": [
 			"@lint",
 			"@phpcs",

--- a/src/Exceptions/InvalidCharsInVatNumberException.php
+++ b/src/Exceptions/InvalidCharsInVatNumberException.php
@@ -9,7 +9,7 @@ class InvalidCharsInVatNumberException extends VatNumberException
 {
 
 	/** @var array<int, string> */
-	private $invalidChars = [];
+	private array $invalidChars = [];
 
 
 	/**

--- a/src/Exceptions/InvalidCharsInVatNumberException.php
+++ b/src/Exceptions/InvalidCharsInVatNumberException.php
@@ -3,8 +3,6 @@ declare(strict_types = 1);
 
 namespace JakubJachym\VatCalculator\Exceptions;
 
-use Throwable;
-
 class InvalidCharsInVatNumberException extends VatNumberException
 {
 
@@ -15,16 +13,15 @@ class InvalidCharsInVatNumberException extends VatNumberException
 	/**
 	 * @param array<int, array{0: string, 1: int}> $invalidChars
 	 * @param string $vatNumber
-	 * @param Throwable|null $previous
 	 */
-	public function __construct(array $invalidChars, string $vatNumber, Throwable $previous = null)
+	public function __construct(array $invalidChars, string $vatNumber)
 	{
 		$chars = [];
 		foreach ($invalidChars as $invalidChar) {
 			$chars[] = sprintf('%s (0x%s) at offset %d', $invalidChar[0], bin2hex($invalidChar[0]), $invalidChar[1]);
 			$this->invalidChars[$invalidChar[1]] = $invalidChar[0];
 		}
-		parent::__construct("VAT number {$vatNumber} contains invalid characters: " . implode(', ', $chars), 0, $previous);
+		parent::__construct("VAT number {$vatNumber} contains invalid characters: " . implode(', ', $chars));
 	}
 
 

--- a/src/Exceptions/UnsupportedCountryException.php
+++ b/src/Exceptions/UnsupportedCountryException.php
@@ -3,14 +3,12 @@ declare(strict_types = 1);
 
 namespace JakubJachym\VatCalculator\Exceptions;
 
-use Throwable;
-
 class UnsupportedCountryException extends VatNumberException
 {
 
-	public function __construct(string $countryCode, int $code = 0, Throwable $previous = null)
+	public function __construct(string $countryCode)
 	{
-		parent::__construct('Unsupported/non-EU country ' . $countryCode, $code, $previous);
+		parent::__construct('Unsupported/non-EU country ' . $countryCode);
 	}
 
 }

--- a/src/VatCalculator.php
+++ b/src/VatCalculator.php
@@ -9,7 +9,6 @@ use JakubJachym\VatCalculator\Exceptions\UnsupportedCountryException;
 use JakubJachym\VatCalculator\Exceptions\VatCheckUnavailableException;
 use SoapClient;
 use SoapFault;
-use stdClass;
 
 class VatCalculator
 {
@@ -164,7 +163,12 @@ class VatCalculator
 				$requesterVatNumber = $this->businessVatNumber;
 			}
 
-			/** @var stdClass $result */
+			/** @var object{
+					valid: bool,
+					countryCode: string,
+					vatNumber: string,
+					requestIdentifier: string|null
+				} $result */
 			$result = $this->soapClient->checkVatApprox([
 				'countryCode' => $countryCode,
 				'vatNumber' => $vatNumber,

--- a/src/VatCalculator.php
+++ b/src/VatCalculator.php
@@ -17,27 +17,16 @@ class VatCalculator
 	/**
 	 * VAT Service check URL provided by the EU.
 	 */
-	public const VAT_SERVICE_URL = 'https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl';
+	public const string VAT_SERVICE_URL = 'https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl';
 
-	/** @var SoapClient */
-	private $soapClient;
-
-	/** @var VatRates */
-	private $vatRates;
-
-	/** @var string */
-	private $businessCountryCode;
-
-	/** @var string */
-	private $businessVatNumber;
-
-	/** @var float */
-	private $timeout;
+	private SoapClient $soapClient;
+	private ?string $businessCountryCode = null;
+	private ?string $businessVatNumber = null;
+	private float $timeout;
 
 
-	public function __construct(VatRates $vatRates, ?string $businessCountryCode = null, ?string $businessVatNumber = null, ?float $timeout = null)
+	public function __construct(private readonly VatRates $vatRates, ?string $businessCountryCode = null, ?string $businessVatNumber = null, ?float $timeout = null)
 	{
-		$this->vatRates = $vatRates;
 		if ($businessCountryCode) {
 			$this->setBusinessCountryCode($businessCountryCode);
 		}

--- a/src/VatCalculator.php
+++ b/src/VatCalculator.php
@@ -22,10 +22,9 @@ class VatCalculator
 	private SoapClient $soapClient;
 	private ?string $businessCountryCode = null;
 	private ?string $businessVatNumber = null;
-	private float $timeout;
 
 
-	public function __construct(private readonly VatRates $vatRates, ?string $businessCountryCode = null, ?string $businessVatNumber = null, ?float $timeout = null)
+	public function __construct(private readonly VatRates $vatRates, ?string $businessCountryCode = null, ?string $businessVatNumber = null)
 	{
 		if ($businessCountryCode) {
 			$this->setBusinessCountryCode($businessCountryCode);
@@ -33,7 +32,6 @@ class VatCalculator
 		if ($businessVatNumber) {
 			$this->setBusinessVatNumber($businessVatNumber);
 		}
-		$this->timeout = $timeout ?? (float)ini_get('default_socket_timeout');
 	}
 
 
@@ -162,18 +160,6 @@ class VatCalculator
 		}
 
 		try {
-			if ($this->soapClient === null) {
-				$this->soapClient = new SoapClient(
-					self::VAT_SERVICE_URL,
-					[
-						'stream_context' => stream_context_create([
-							'http' => [
-								'timeout' => $this->timeout,
-							],
-						]),
-					],
-				);
-			}
 			if ($requesterVatNumber === null) {
 				$requesterVatNumber = $this->businessVatNumber;
 			}

--- a/src/VatDetails.php
+++ b/src/VatDetails.php
@@ -6,25 +6,8 @@ namespace JakubJachym\VatCalculator;
 class VatDetails
 {
 
-	/** @var bool */
-	private $valid;
-
-	/** @var string */
-	private $countryCode;
-
-	/** @var string */
-	private $vatNumber;
-
-	/** @var string|null */
-	private $requestId;
-
-
-	public function __construct(bool $valid, string $countryCode, string $vatNumber, ?string $requestId)
+	public function __construct(private bool $valid, private string $countryCode, private string $vatNumber, private ?string $requestId)
 	{
-		$this->valid = $valid;
-		$this->countryCode = $countryCode;
-		$this->vatNumber = $vatNumber;
-		$this->requestId = $requestId;
 	}
 
 

--- a/src/VatPrice.php
+++ b/src/VatPrice.php
@@ -6,25 +6,8 @@ namespace JakubJachym\VatCalculator;
 class VatPrice
 {
 
-	/** @var float */
-	private $netPrice;
-
-	/** @var float */
-	private $price;
-
-	/** @var float */
-	private $taxValue;
-
-	/** @var float */
-	private $taxRate;
-
-
-	public function __construct(float $netPrice, float $price, float $taxValue, float $taxRate)
+	public function __construct(private readonly float $netPrice, private readonly float $price, private readonly float $taxValue, private readonly float $taxRate)
 	{
-		$this->netPrice = $netPrice;
-		$this->price = $price;
-		$this->taxValue = $taxValue;
-		$this->taxRate = $taxRate;
 	}
 
 

--- a/src/VatRates.php
+++ b/src/VatRates.php
@@ -13,16 +13,16 @@ use JakubJachym\VatCalculator\Exceptions\NoVatRulesForCountryException;
  */
 class VatRates
 {
-	public const GENERAL = null;
-	public const STANDARD_RATE = "standard";
-	public const REDUCED_RATE = "reduced";
-	public const REDUCED_2ND_RATE = "reduced-second";
-	public const SUPER_REDUCED_RATE = "super-reduced";
-	public const PARKING_RATE = "parking";
+	public const null GENERAL = null;
+	public const string STANDARD_RATE = "standard";
+	public const string REDUCED_RATE = "reduced";
+	public const string REDUCED_2ND_RATE = "reduced-second";
+	public const string SUPER_REDUCED_RATE = "super-reduced";
+	public const string PARKING_RATE = "parking";
 
 	// Kept for backwards compatibility
-	public const HIGH = self::STANDARD_RATE;
-	public const LOW = self::REDUCED_RATE;
+	public const string HIGH = self::STANDARD_RATE;
+	public const string LOW = self::REDUCED_RATE;
 
 	/**
 	 * All available tax rules and their exceptions.
@@ -31,7 +31,7 @@ class VatRates
 	 *
 	 * @var array<string, CountryTaxRules>
 	 */
-	private $taxRules = [
+	private array $taxRules = [
 		'AT' => [ // Austria - https://www.wko.at/steuern/umsatzsteuer-ueberblick-tabelle#heading_Steuers_tze
 			'rate' => 0.20,
 			'rates' => [
@@ -328,7 +328,7 @@ class VatRates
 	 *
 	 * @var array<string, CountryTaxRules>
 	 */
-	private $optionalTaxRules = [
+	private array $optionalTaxRules = [
 		'CH' => [ // Switzerland
 			'rate' => 0.081,
 			'since' => [
@@ -371,7 +371,7 @@ class VatRates
 	 *
 	 * @var PostalCodeTaxExceptions
 	 */
-	private $postalCodeExceptions = [
+	private array $postalCodeExceptions = [
 		'AT' => [
 			[
 				'postalCode' => '/^6691$/',
@@ -507,7 +507,7 @@ class VatRates
 	 *
 	 * @var PostalCodeTaxExceptions
 	 */
-	private $optionalPostalCodeExceptions = [
+	private array $optionalPostalCodeExceptions = [
 		'GB' => [
 			// Akrotiri
 			[
@@ -523,7 +523,7 @@ class VatRates
 	];
 
 	/** @var DateTimeImmutable */
-	private $now;
+	private DateTimeImmutable $now;
 
 
 	public function __construct()
@@ -540,7 +540,7 @@ class VatRates
 	{
 		$country = strtoupper($country);
 		if (!isset($this->optionalTaxRules[$country])) {
-			throw new NoVatRulesForCountryException("No optional tax rules specified for {$country}");
+			throw new NoVatRulesForCountryException("No optional tax rules specified for $country");
 		}
 		$this->taxRules[$country] = $this->optionalTaxRules[$country];
 		if (isset($this->optionalPostalCodeExceptions[$country])) {

--- a/src/VatRates.php
+++ b/src/VatRates.php
@@ -583,7 +583,14 @@ class VatRates
 				}
 				if (isset($postalCodeException['name'], $this->taxRules[$postalCodeException['code']]['exceptions'])) {
 					$rules = $this->taxRules[$postalCodeException['code']]['exceptions'][$postalCodeException['name']];
-					return is_array($rules) ? $rules[$type] : $rules;
+					if (!is_array($rules)) {
+						return $rules;
+					}
+					if ($type !== VatRates::GENERAL && isset($rules['rates'][$type]) && is_float($rules['rates'][$type])) {
+						return $rules['rates'][$type];
+					}
+
+					return $rules['rate'];
 				}
 				return $this->getRules($postalCodeException['code'], $date)['rate'];
 			}

--- a/src/VatRates.php
+++ b/src/VatRates.php
@@ -8,8 +8,24 @@ use DateTimeInterface;
 use JakubJachym\VatCalculator\Exceptions\NoVatRulesForCountryException;
 
 /**
- * @phpstan-type CountryTaxRules array{rate: float, rates?: array<string, float>, exceptions?: array<string, float|array<string|null, float>>, since?: array<string, array{rate: float, rates?: array<string, float>}>}
- * @phpstan-type PostalCodeTaxExceptions array<string, array<int, array{postalCode: string, code: string, name?: string, city?: string}>>
+ * @phpstan-type CountryTaxRules array{
+ *     rate: float,
+ *     rates?: array<string, float>,
+ *     exceptions?: array<string, float|array{
+ *         rate: float,
+ *         rates?: array<string, float>
+ *     }>,
+ *     since?: array<string, array{
+ *         rate: float,
+ *         rates?: array<string, float>
+ *     }>
+ * }
+ * @phpstan-type PostalCodeTaxExceptions array<string, array<int, array{
+ *     postalCode: string,
+ *     code: string,
+ *     name?: string,
+ *     city?: string
+ * }>>
  */
 class VatRates
 {
@@ -113,7 +129,7 @@ class VatRates
 			'rates' => [
 				self::STANDARD_RATE => 0.21,
 				self::REDUCED_RATE => 0.10,
-				self::REDUCED_2ND_RATE => 0.04,
+				self::SUPER_REDUCED_RATE => 0.04,
 			],
 			'exceptions' => [
 				'Canary Islands' => 0,
@@ -214,9 +230,20 @@ class VatRates
 		],
 		'LV' => [ // Latvia
 			'rate' => 0.21,
+			'rates' => [
+				self::STANDARD_RATE => 0.21,
+				self::REDUCED_RATE => 0.12,
+				self::REDUCED_2ND_RATE => 0.05,
+			],
 		],
-		'MT' => [ // Malta
+		'MT' => [ // Malta - https://mtca.gov.mt/business-tax/vat1/vat-compliance/vat-rates/vat-rates
 			'rate' => 0.18,
+			'rates' => [
+				self::STANDARD_RATE => 0.18,
+				self::REDUCED_RATE => 0.12,
+				self::REDUCED_2ND_RATE => 0.07,
+				self::SUPER_REDUCED_RATE => 0.05,
+			],
 		],
 		'NL' => [ // Netherlands
 			'rate' => 0.21,
@@ -225,14 +252,38 @@ class VatRates
 				self::REDUCED_RATE => 0.09,
 			],
 		],
-		'PL' => [ // Poland
+		'PL' => [ // Poland - https://www.biznes.gov.pl/en/portal/004162#3
 			'rate' => 0.23,
+			'rates' => [
+				self::STANDARD_RATE => 0.23,
+				self::REDUCED_RATE => 0.08,
+				self::REDUCED_2ND_RATE => 0.05,
+			],
 		],
-		'PT' => [ // Portugal
+		'PT' => [ // Portugal - https://www2.gov.pt/en/cidadaos-europeus-viajar-viver-e-fazer-negocios-em-portugal/impostos-para-atividades-economicas-em-portugal/imposto-sobre-valor-acrescentado-iva-em-portugal
 			'rate' => 0.23,
+			'rates' => [
+				self::STANDARD_RATE => 0.23,
+				self::REDUCED_RATE => 0.13,
+				self::REDUCED_2ND_RATE => 0.06,
+			],
 			'exceptions' => [
-				'Azores' => 0.16,
-				'Madeira' => 0.22,
+				'Azores' => [
+					'rate' => 0.16,
+					'rates' => [
+						self::STANDARD_RATE => 0.16,
+						self::REDUCED_RATE => 0.09,
+						self::REDUCED_2ND_RATE => 0.04,
+					],
+				],
+				'Madeira' => [
+					'rate' => 0.22,
+					'rates' => [
+						self::STANDARD_RATE => 0.22,
+						self::REDUCED_RATE => 0.12,
+						self::REDUCED_2ND_RATE => 0.05,
+					],
+				],
 			],
 		],
 		'RO' => [ // Romania
@@ -242,11 +293,21 @@ class VatRates
 				self::REDUCED_RATE => 0.11,
 			],
 		],
-		'SE' => [ // Sweden
+		'SE' => [ // Sweden - https://verksamt.se/en/taxes-contributions/vat/vat-rates
 			'rate' => 0.25,
+			'rates' => [
+				self::STANDARD_RATE => 0.25,
+				self::REDUCED_RATE => 0.12,
+				self::REDUCED_2ND_RATE => 0.06,
+			],
 		],
-		'SI' => [ // Slovenia
+		'SI' => [ // Slovenia - https://spot.gov.si/en/info/taxes/value-added-tax-vat
 			'rate' => 0.22,
+			'rates' => [
+				self::STANDARD_RATE => 0.22,
+				self::REDUCED_RATE => 0.095,
+				self::REDUCED_2ND_RATE => 0.05,
+			],
 		],
 		'SK' => [ // Slovakia
 			'rate' => 0.23,
@@ -285,6 +346,10 @@ class VatRates
 		],
 		'GB' => [ // United Kingdom
 			'rate' => 0.20,
+			'rates' => [
+				self::STANDARD_RATE => 0.20,
+				self::REDUCED_RATE => 0.05,
+			],
 			'exceptions' => [
 				// UK RAF Bases in Cyprus are taxed at Cyprus rate
 				'Akrotiri' => 0.19,
@@ -293,9 +358,19 @@ class VatRates
 		],
 		'NO' => [ // Norway
 			'rate' => 0.25,
+			'rates' => [
+				self::STANDARD_RATE => 0.25,
+				self::REDUCED_RATE => 0.15,
+				self::REDUCED_2ND_RATE => 0.12,
+			],
 		],
 		'TR' => [ // Turkey
-			'rate' => 0.18,
+			'rate' => 0.20,
+			'rates' => [
+				self::STANDARD_RATE => 0.20,
+				self::REDUCED_RATE => 0.10,
+				self::REDUCED_2ND_RATE => 0.01,
+			],
 		],
 	];
 
@@ -420,12 +495,12 @@ class VatRates
 		],
 		'PT' => [
 			[
-				'postalCode' => '/^9[0-4]\d{2,}$/',
+				'postalCode' => '/^9[0-4]\d{2}($|-\d{3}$)/',
 				'code' => 'PT',
 				'name' => 'Madeira',
 			],
 			[
-				'postalCode' => '/^9[5-9]\d{2,}$/',
+				'postalCode' => '/^9[5-9]\d{2}($|-\d{3}$)/',
 				'code' => 'PT',
 				'name' => 'Azores',
 			],
@@ -519,7 +594,7 @@ class VatRates
 					if (!is_array($rules)) {
 						return $rules;
 					}
-					if ($type !== VatRates::GENERAL && isset($rules['rates'][$type]) && is_float($rules['rates'][$type])) {
+					if ($type !== VatRates::GENERAL && isset($rules['rates'][$type])) {
 						return $rules['rates'][$type];
 					}
 
@@ -600,7 +675,11 @@ class VatRates
 		if (isset($taxRules['exceptions'])) {
 			foreach ($taxRules['exceptions'] as $exceptions) {
 				foreach ((array)$exceptions as $exception) {
-					$rates[] = $exception;
+					if (is_array($exception)) {
+						$rates = array_merge($rates, array_values($exception));
+					} else {
+						$rates[] = $exception;
+					}
 				}
 			}
 		}

--- a/src/VatRates.php
+++ b/src/VatRates.php
@@ -70,29 +70,16 @@ class VatRates
 		],
 		'CZ' => [ // Czech Republic
 			'rate' => 0.21,
-			'since' => [
-				'2024-01-01 00:00:00 Europe/Prague' => [
-					'rate' => 0.21,
-					'rates' => [
-						self::STANDARD_RATE => 0.21,
-						self::REDUCED_RATE => 0.12,
-					],
-				],
+			'rates' => [
+				self::STANDARD_RATE => 0.21,
+				self::REDUCED_RATE => 0.12,
 			],
 		],
 		'DE' => [ // Germany
 			'rate' => 0.19,
-			'since' => [
-				'2021-01-01 00:00:00 Europe/Berlin' => [
-					'rate' => 0.19,
-					'rates' => [
-						self::STANDARD_RATE => 0.19,
-						self::REDUCED_RATE => 0.07,
-					],
-				],
-				'2020-07-01 00:00:00 Europe/Berlin' => [
-					'rate' => 0.16,
-				],
+			'rates' => [
+				self::STANDARD_RATE => 0.19,
+				self::REDUCED_RATE => 0.07,
 			],
 			'exceptions' => [
 				'Heligoland' => 0,
@@ -188,19 +175,11 @@ class VatRates
 		],
 		'IE' => [ // Ireland
 			'rate' => 0.23,
-			'since' => [
-				'2021-03-01 00:00:00 Europe/Dublin' => [
-					'rate' => 0.23,
-					'rates' => [
-						self::STANDARD_RATE => 0.23,
-						self::REDUCED_RATE => 0.135,
-						self::REDUCED_2ND_RATE => 0.09,
-						self::SUPER_REDUCED_RATE => 0.048,
-					],
-				],
-				'2020-09-01 00:00:00 Europe/Dublin' => [
-					'rate' => 0.21,
-				],
+			'rates' => [
+				self::STANDARD_RATE => 0.23,
+				self::REDUCED_RATE => 0.135,
+				self::REDUCED_2ND_RATE => 0.09,
+				self::SUPER_REDUCED_RATE => 0.048,
 			],
 		],
 		'IT' => [ // Italy
@@ -226,26 +205,11 @@ class VatRates
 		],
 		'LU' => [ // Luxembourg
 			'rate' => 0.17,
-			'since' => [
-				'2024-01-01 00:00:00 Europe/Luxembourg' => [
-					'rate' => 0.17,
-					'rates' => [
-						self::STANDARD_RATE => 0.17,
-						self::REDUCED_RATE => 0.08,
-						self::SUPER_REDUCED_RATE => 0.03,
-						self::PARKING_RATE => 0.14,
-					],
-				],
-				// https://legilux.public.lu/eli/etat/leg/loi/2022/10/26/a534/jo
-				'2023-01-01 00:00:00 Europe/Luxembourg' => [
-					'rate' => 0.16,
-					'rates' => [
-						self::STANDARD_RATE => 0.16,
-						self::REDUCED_RATE => 0.07,
-						self::SUPER_REDUCED_RATE => 0.03,
-						self::PARKING_RATE => 0.13,
-					],
-				],
+			'rates' => [
+				self::STANDARD_RATE => 0.17,
+				self::REDUCED_RATE => 0.08,
+				self::SUPER_REDUCED_RATE => 0.03,
+				self::PARKING_RATE => 0.14,
 			],
 		],
 		'LV' => [ // Latvia
@@ -285,29 +249,11 @@ class VatRates
 			'rate' => 0.22,
 		],
 		'SK' => [ // Slovakia
-			'rate' => 0.20,
+			'rate' => 0.23,
 			'rates' => [
-				self::STANDARD_RATE => 0.20,
-				self::REDUCED_RATE => 0.10,
+				self::STANDARD_RATE => 0.23,
+				self::REDUCED_RATE => 0.19,
 				self::REDUCED_2ND_RATE => 0.05,
-			],
-			'since' => [
-				'2025-01-01 00:00:00 Europe/Bratislava' => [
-					'rate' => 0.23,
-					'rates' => [
-						self::STANDARD_RATE => 0.23,
-						self::REDUCED_RATE => 0.19,
-						self::REDUCED_2ND_RATE => 0.05,
-					],
-				],
-				'2024-01-01 00:00:00 Europe/Bratislava' => [
-					'rate' => 0.20,
-					'rates' => [
-						self::STANDARD_RATE => 0.20,
-						self::REDUCED_RATE => 0.10,
-						self::REDUCED_2ND_RATE => 0.05,
-					],
-				],
 			],
 		],
 
@@ -331,23 +277,10 @@ class VatRates
 	private array $optionalTaxRules = [
 		'CH' => [ // Switzerland
 			'rate' => 0.081,
-			'since' => [
-				'2024-01-01 00:00:00 Europe/Zurich' => [
-					'rate' => 0.081,
-					'rates' => [
-						self::STANDARD_RATE => 0.081,
-						self::REDUCED_RATE => 0.026,
-						self::SUPER_REDUCED_RATE => 0.038,
-					],
-				],
-				'2018-01-01 00:00:00 Europe/Zurich' => [
-					'rate' => 0.077,
-					'rates' => [
-						self::STANDARD_RATE => 0.077,
-						self::REDUCED_RATE => 0.025,
-						self::SUPER_REDUCED_RATE => 0.037,
-					],
-				],
+			'rates' => [
+				self::STANDARD_RATE => 0.081,
+				self::REDUCED_RATE => 0.026,
+				self::SUPER_REDUCED_RATE => 0.038,
 			],
 		],
 		'GB' => [ // United Kingdom

--- a/src/VatRates.php
+++ b/src/VatRates.php
@@ -32,25 +32,13 @@ class VatRates
 	 * @var array<string, CountryTaxRules>
 	 */
 	private $taxRules = [
-		'AT' => [ // Austria
+		'AT' => [ // Austria - https://www.wko.at/steuern/umsatzsteuer-ueberblick-tabelle#heading_Steuers_tze
 			'rate' => 0.20,
 			'rates' => [
 				self::STANDARD_RATE => 0.20,
 				self::REDUCED_RATE => 0.10,
 				self::REDUCED_2ND_RATE => 0.13,
-				self::SUPER_REDUCED_RATE => 0.05,
 				self::PARKING_RATE => 0.13,
-			],
-			'since' => [
-				'2022-01-01 00:00:00 Europe/Vienna' => [
-					'rate' => 0.20,
-					'rates' => [
-						self::STANDARD_RATE => 0.20,
-						self::REDUCED_RATE => 0.10,
-						self::REDUCED_2ND_RATE => 0.13,
-						self::PARKING_RATE => 0.13,
-					],
-				],
 			],
 			'exceptions' => [
 				'Jungholz' => 0.19,
@@ -114,18 +102,12 @@ class VatRates
 		'DK' => [ // Denmark
 			'rate' => 0.25,
 		],
-		'EE' => [ // Estonia
-			'rate' => 0.20,
-			'since' => [
-				'2024-01-01 00:00:00 Europe/Tallinn' => [
-					'rate' => 0.22,
-					'rates' => [
-						self::STANDARD_RATE => 0.22,
-						self::REDUCED_RATE => 0.09,
-						self::REDUCED_2ND_RATE => 0.05,
-					],
-
-				],
+		'EE' => [ // Estonia - https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax/vat-rates-and-supply-exempt-tax
+			'rate' => 0.24,
+			'rates' => [
+				self::STANDARD_RATE => 0.24,
+				self::REDUCED_RATE => 0.13,
+				self::REDUCED_2ND_RATE => 0.09,
 			],
 		],
 		'EL' => [ // Hellenic Republic (Greece)
@@ -139,13 +121,12 @@ class VatRates
 				'Mount Athos' => 0,
 			],
 		],
-		'ES' => [ // Spain
+		'ES' => [ // Spain - https://administracion.gob.es/pag_Home/en/Tu-espacio-europeo/derechos-obligaciones/empresas/impuestos/IVA/tipos-exenciones.html
 			'rate' => 0.21,
 			'rates' => [
 				self::STANDARD_RATE => 0.21,
 				self::REDUCED_RATE => 0.10,
-				self::REDUCED_2ND_RATE => 0.05,
-				self::SUPER_REDUCED_RATE => 0.04,
+				self::REDUCED_2ND_RATE => 0.04,
 			],
 			'exceptions' => [
 				'Canary Islands' => 0,
@@ -153,22 +134,12 @@ class VatRates
 				'Melilla' => 0,
 			],
 		],
-		'FI' => [ // Finland
-			'rate' => 0.24,
+		'FI' => [ // Finland - https://vm.fi/en/value-added-tax
+			'rate' => 0.255,
 			'rates' => [
-				self::STANDARD_RATE => 0.24,
-				self::REDUCED_RATE => 0.10,
-				self::REDUCED_2ND_RATE => 0.14,
-			],
-			'since' => [
-				'2024-09-01 00:00:00 Europe/Helsinki' => [
-					'rate' => 0.255,
-					'rates' => [
-						self::STANDARD_RATE => 0.255,
-						self::REDUCED_RATE => 0.10,
-						self::REDUCED_2ND_RATE => 0.14,
-					],
-				],
+				self::STANDARD_RATE => 0.255,
+				self::REDUCED_RATE => 0.135,
+				self::REDUCED_2ND_RATE => 0.10,
 			],
 		],
 		'FR' => [ // France
@@ -301,7 +272,11 @@ class VatRates
 			],
 		],
 		'RO' => [ // Romania
-			'rate' => 0.19,
+			'rate' => 0.21,
+			'rates' => [
+				self::STANDARD_RATE => 0.21,
+				self::REDUCED_RATE => 0.11,
+			],
 		],
 		'SE' => [ // Sweden
 			'rate' => 0.25,

--- a/tests/VatCalculatorTest.php
+++ b/tests/VatCalculatorTest.php
@@ -16,16 +16,11 @@ use stdClass;
 class VatCalculatorTest extends TestCase
 {
 
-	private const DATE = '2020-06-30 23:59:59 Europe/Berlin';
+	private const string DATE = '2026-06-30 23:59:59 Europe/Berlin';
 
-	/** @var VatCalculator */
-	private $vatCalculator;
-
-	/** @var SoapClient */
-	private $vatCheck;
-
-	/** @var VatRates */
-	private $vatRates;
+	private VatCalculator $vatCalculator;
+	private SoapClient $vatCheck;
+	private VatRates $vatRates;
 
 
 	protected function setUp(): void

--- a/tests/VatRatesTest.php
+++ b/tests/VatRatesTest.php
@@ -54,11 +54,6 @@ class VatRatesTest extends TestCase
 		$this->assertEquals(0.19, $this->vatRates->getTaxRateForLocation('DE', null));
 		$this->assertEquals(0.19, $this->vatRates->getTaxRateForLocation('DE', null, VatRates::GENERAL, new DateTimeImmutable($date)));
 
-		$date = '2020-07-01 00:00:00 Europe/Berlin';
-		$property->setValue($this->vatRates, new DateTimeImmutable($date));
-		$this->assertEquals(0.16, $this->vatRates->getTaxRateForLocation('DE', null));
-		$this->assertEquals(0.16, $this->vatRates->getTaxRateForLocation('DE', null, VatRates::GENERAL, new DateTimeImmutable($date)));
-
 		$date = '2021-01-01 00:00:00 Europe/Berlin';
 		$property->setValue($this->vatRates, new DateTimeImmutable($date));
 		$this->assertEquals(0.19, $this->vatRates->getTaxRateForLocation('DE', null));
@@ -86,7 +81,7 @@ class VatRatesTest extends TestCase
 	{
 		$this->assertEquals([0.20, 0.10, 0.13, 0.19], $this->vatRates->getAllKnownRates('AT'));
 		$this->assertEquals([0.21, 0.12], $this->vatRates->getAllKnownRates('CZ'));
-		$this->assertEquals([0.19, 0, 0.07, 0.16], $this->vatRates->getAllKnownRates('DE'));
+		$this->assertEquals([0.19, 0.07, 0], $this->vatRates->getAllKnownRates('DE'));
 		$this->assertEquals([0.21, 0.09], $this->vatRates->getAllKnownRates('NL'));
 	}
 

--- a/tests/VatRatesTest.php
+++ b/tests/VatRatesTest.php
@@ -85,7 +85,7 @@ class VatRatesTest extends TestCase
 
 	public function testGetAllKnownRates(): void
 	{
-		$this->assertEquals([0.20, 0.10, 0.13, 0.05, 0.19], $this->vatRates->getAllKnownRates('AT'));
+		$this->assertEquals([0.20, 0.10, 0.13, 0.19], $this->vatRates->getAllKnownRates('AT'));
 		$this->assertEquals([0.21, 0.12], $this->vatRates->getAllKnownRates('CZ'));
 		$this->assertEquals([0.19, 0, 0.07, 0.16], $this->vatRates->getAllKnownRates('DE'));
 		$this->assertEquals([0.21, 0.09], $this->vatRates->getAllKnownRates('NL'));

--- a/tests/VatRatesTest.php
+++ b/tests/VatRatesTest.php
@@ -67,6 +67,14 @@ class VatRatesTest extends TestCase
 	}
 
 
+	public function testGetRatesExceptionsPtMadeira(): void
+	{
+		$this->assertEquals(0.22, $this->vatRates->getTaxRateForLocation('PT', '9000-059', VatRates::STANDARD_RATE));
+		$this->assertEquals(0.12, $this->vatRates->getTaxRateForLocation('PT', '9000-059', VatRates::REDUCED_RATE));
+		$this->assertEquals(0.05, $this->vatRates->getTaxRateForLocation('PT', '9000-059', VatRates::REDUCED_2ND_RATE));
+	}
+
+
 	public function testGetRatesForLuxembourg(): void
 	{
 		$this->assertEquals(0.17, $this->vatRates->getTaxRateForLocation('LU', null));

--- a/tests/VatRatesTest.php
+++ b/tests/VatRatesTest.php
@@ -11,8 +11,7 @@ use ReflectionClass;
 class VatRatesTest extends TestCase
 {
 
-	/** @var VatRates */
-	private $vatRates;
+	private VatRates $vatRates;
 
 
 	protected function setUp(): void


### PR DESCRIPTION
Updated VAT rates for the following countries:
  - Austria
  - Estonia
  - Finland
  - Latvia
  - Malta
  - Poland
  - Portugal (including the Azores and Madeira)
  - Romania
  - Spain
  - Sweden
  - Slovenia

From non-EU:
  - United Kingdom
  - Norway
  - Turkey